### PR TITLE
[github.io] disable hatena bookmark comments

### DIFF
--- a/_includes/hatena-nocomment.html
+++ b/_includes/hatena-nocomment.html
@@ -1,0 +1,1 @@
+<meta name="Hatena::Bookmark" content="nocomment" />

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -86,3 +86,4 @@ format:
     toc-depth: 2
     toc-expand: 2
     toc: true
+    include-in-header: _includes/hatena-nocomment.html


### PR DESCRIPTION
# PR: [github.io] disable hatena bookmark comments

<!-- ===== PR本文（ここまでがPR作成時に使用） ===== -->

Closes #32

## Summary

Added a meta tag to HTML headers on all pages to disable Hatena Bookmark comment functionality.

## What I did

- Created `_includes/hatena-nocomment.html` file with the Hatena Bookmark comment disabling meta tag
- Added `include-in-header` configuration to `_quarto.yml` to apply the meta tag to all pages

## Testing

- Verified implementation: Confirmed correct meta tag (`<meta name="Hatena::Bookmark" content="nocomment" />`) is configured
- The meta tag will be added to all HTML page headers after the next build
