### PR TITLE
docs(blog): add agent org graph articles

### DIFF
--- a/blog/2026-07-21-agent-org-graph-in-tmux.qmd
+++ b/blog/2026-07-21-agent-org-graph-in-tmux.qmd
@@ -1,0 +1,200 @@
+---
+title: "tmux に置く最小限のエージェント組織図"
+author: uma-chan
+categories:
+  - "blog"
+  - "tech-ai"
+  - "ai-generated"
+date: 2026-07-21 21:20:00 +0900
+date-modified: last-modified
+description: |
+  Graph Engineering の語彙は、複数エージェント構成を考えるうえで役に立つ。tmux-a2a-postman は実行グラフのフレームワークではないが、ターミナル上のエージェントに、役割、引き継ぎの辺、Markdown メール、返信責務を持つ小さな組織図を与える。
+image: "/assets/common/icon_hhkb3_large.jpg"
+---
+
+## 1. 欲しかったグラフ
+
+「Graph Engineering」という言葉を、複数エージェント構成の文脈で見ることが増えてきた。まだ新しい言葉だが、向いている方向は分かりやすい。エージェントを長い一つの会話として扱うのではなく、登場人物を名付け、辺を名付け、引き継ぎを見えるようにする。
+
+ただし、この語彙はすぐ大きくなりすぎる。グラフと言った瞬間に、ワークフロー実行基盤、サービス間プロトコル、プランナー、メッセージキュー、レビューシステム、単なる図が混ざる。
+
+私が欲しかったグラフはもっと小さい。
+
+欲しかったのは、ターミナル上のエージェントのローカルな地図だった。
+
+- どの役割が人間と話すのか
+- どの役割が作業を調整するのか
+- どの役割が実装するのか
+- どの役割がレビューするのか
+- 誰が誰に話してよいのか
+- どの依頼がまだ返信待ちなのか
+
+`tmux-a2a-postman` が与えるのは、この形である。LangGraph や AutoGen の代替ではない。A2A プロトコルの実装でもない。tmux ペインのための、Markdown で書くローカルな会話トポロジーである。
+
+Repository: <https://github.com/i9wa4/tmux-a2a-postman>
+
+## 2. 実行グラフと会話トポロジー
+
+ここは分けておきたい。
+
+[LangGraph の Graph API](https://docs.langchain.com/oss/python/langgraph/graph-api) は、エージェントのワークフローを state、nodes、edges でモデル化する。node はロジックを実行して state の更新を返す。edge は次にどの node を実行するかを決める。これは実行構造である。
+
+[AutoGen GraphFlow](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/graph-flow.html) も、エージェントを node、許可された実行経路を edge とする有向グラフを説明している。順次、並列、条件分岐、ループを扱う。
+
+[Google ADK workflows](https://adk.dev/workflows/) は、より予測可能で信頼しやすいシステムのために、複数エージェント、複数 node のアプリケーションを扱う。[A2A の説明](https://adk.dev/a2a/intro/) は、サービス、チーム、言語、フレームワークをまたいでエージェントが通信するための話である。
+
+これらは postman より強く、広い面を持っている。
+
+`tmux-a2a-postman` は、グラフ実行基盤の中で node を実行しない。node は、すでに動いている tmux ペインである。edge は、許可された会話経路である。message は Markdown メールである。daemon は配送、未読と既読、返信必須の依頼、状態を追跡する。
+
+だから比較するなら、もっと狭く言うのがよい。postman は、ローカルなターミナルエージェントチームの組織図、または会話トポロジーである。
+
+## 3. 小さなトポロジー
+
+最小限で役に立つ構成は、図としては地味である。そこがよい。
+
+```{mermaid}
+graph LR
+    messenger["messenger<br/>human-facing"]
+    orchestrator["orchestrator<br/>coordinator"]
+    worker["worker<br/>implementation"]
+    reviewer["reviewer<br/>verification"]
+
+    messenger --- orchestrator
+    orchestrator --- worker
+    orchestrator --- reviewer
+
+    class messenger entry
+    class orchestrator,worker,reviewer role
+    classDef entry fill:#dbeafe,stroke:#2563eb,color:#0f172a
+    classDef role fill:#f8fafc,stroke:#64748b,color:#0f172a
+```
+
+`postman.md` では、同じ内容を普通の Markdown として書く。
+
+````{.markdown filename="postman.md"}
+## `edges`
+
+```mermaid
+graph LR
+    messenger --- orchestrator
+    orchestrator --- worker
+    orchestrator --- reviewer
+    class messenger ui_node
+    classDef ui_node fill:#e0f2fe
+```
+
+## `messenger`
+
+### `role`
+
+Human-facing transport role. Relay work to orchestrator.
+
+## `orchestrator`
+
+### `role`
+
+Coordinator. Delegate implementation to worker and request review from reviewer.
+
+## `worker`
+
+### `role`
+
+Implementation role. Return changed files, checks, evidence, and blockers.
+
+## `reviewer`
+
+### `role`
+
+Verification role. Check the result and return an evidence-backed verdict.
+````
+
+重要なのは装飾ではない。node 名はペインタイトルと役割契約に対応する。`---` の edge は、どの役割がどの役割へメールを送れるかを定義する。`ui_node` class は、最初に人間へ向く役割を示す。
+
+これだけで、ペインの記憶に頼る状態からかなり抜けられる。
+
+## 4. なぜメールボックスがグラフに要るのか
+
+役割のグラフは、仕事がその上を消えずに流れる場合にだけ役に立つ。
+
+ターミナルエージェントには、すでに実行面がある。shell、editor、test command、repository file、長く生きる tmux pane がある。消えやすいのは引き継ぎである。依頼は一つの chat history にあり、reviewer は別の pane で答える。後で人間が「何がまだ開いているのか」と聞くと、みんなで scrollback を読むことになる。
+
+postman は、引き継ぎをローカルな状態に変える。
+
+message には sender と receiver がある。receiver は `pop` で claim する。ある message は送るだけでよい。別の message は reply-required で、正確な input request を開く。完了返信には、evidence、task artifact、original checklist status、remaining blockers を書く。
+
+小さい仕組みだが、運用モデルは変わる。グラフは「orchestrator は worker と話せる」だけではなくなる。「orchestrator がこの依頼を worker に送り、worker が claim し、この返信 slot がまだ開いている」になる。
+
+グラフは記憶を持つ調整地図になる。
+
+## 5. 今の議論の中での位置
+
+エージェントの議論は、prompt から loop、workflow、organization へ上がっている。
+
+[「Loop EngineeringはGraph Engineeringの中にある」](https://aimanavo.com/c/morphox_ai/a/MAfrDjpPkKGUFw) は、エージェントを組織として配線する話として Graph Engineering を扱っている。[TrueFoundry の Graph Engineering 記事](https://www.truefoundry.com/blog/graph-engineering-enterprise-guide) も、topology、router、join、tool、human checkpoint、governance、observability を設計対象として扱う。
+
+これらは、仕様というより潮流を示す記事として読むのがよい。より安定した参照先は、やはり framework docs である。LangGraph、AutoGen、ADK のドキュメントを見ると、node、edge、routing、fan-out、複数エージェント workflow の語彙は、すでに agent engineering の普通の部品になっている。
+
+postman は、その中では org graph 側に寄っている。次の node を決める planner を提供しない。state graph を実行しない。遠隔サービス間の agent communication を標準化しない。一方で、ローカルな組織を読める形にする。
+
+- 安定した役割
+- 宣言された引き継ぎ edge
+- 人間向けの入口 node
+- Markdown の role contract
+- 永続する mail
+- 明示的な reply obligation
+- 人間も別の agent も読める status
+
+これは、ターミナルサイズの Graph Engineering である。
+
+## 6. 役に立つ制約
+
+一番役に立つ制約は、グラフを地味に保つことだ。
+
+エージェント組織図は、最初から二十個の役割を持つべきではない。私の場合は、たいてい四つから始める。
+
+- `messenger` が人間と話す
+- `orchestrator` が仕事を形にして経路を決める
+- `worker` が変更や調査をする
+- `reviewer` が証跡を確認する
+
+必要になれば、approver、critic、operator、release coordinator を足せばよい。ただし小さなグラフだけでも、一つの context window に同居しにくい責務を分けられる。
+
+worker は、人間と話す手順を覚えなくてよい。reviewer は、worker の私的な推論全体を抱えなくてよい。messenger は repository を調べなくてよい。orchestrator は、すべての編集を自分で実行しなくてよい。
+
+edge list は、context の圧力を逃がす弁である。
+
+## 7. 正直な境界
+
+安全境界も書いておく。
+
+postman は調整であって、強制ではない。宣言された edge は process を sandbox しない。command approval thread は OS の permission model ではない。Markdown の role contract は、agent が必ずその通りに振る舞う証明ではない。
+
+これは脚注ではない。比較を正直に保つための中心である。
+
+runtime sandbox、permission、hook、CI、branch protection、人間の承認が必要な場所では、それらを使うべきだ。postman は、postman が得意なことに使う。ローカルな agent の引き継ぎを明示し、点検でき、ひとつの model context を越えて残る状態にすることだ。
+
+Markdown のグラフが実行 framework を置き換えるわけではない。価値は、より重い仕組みが必要になる前に、ローカルな組織を見えるようにすることにある。
+
+## 8. なぜ見せる価値があるのか
+
+この記事の元になった README の変更では、rendered topology のすぐ近くに Mermaid source を置いた。小さな変更だが、プロダクトの考え方はよく出る。
+
+図は言う。これが組織である。
+
+source は言う。これが編集できる契約である。
+
+mailbox は言う。これが起きたことである。
+
+今のところ、これが私の見つけた最小限で役に立つエージェント組織図である。tmux に収まるのは、最初の問題が分散グラフを実行することではないからだ。最初の問題は、次の message を誰が持っているのかを知ることである。
+
+## Sources
+
+- [`tmux-a2a-postman`](https://github.com/i9wa4/tmux-a2a-postman)
+- [LangGraph Graph API](https://docs.langchain.com/oss/python/langgraph/graph-api)
+- [LangGraph workflows and agents](https://docs.langchain.com/oss/python/langgraph/workflows-agents)
+- [AutoGen GraphFlow](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/graph-flow.html)
+- [Google ADK workflows](https://adk.dev/workflows/)
+- [Google ADK A2A introduction](https://adk.dev/a2a/intro/)
+- [Loop EngineeringはGraph Engineeringの中にある](https://aimanavo.com/c/morphox_ai/a/MAfrDjpPkKGUFw)
+- [TrueFoundry: Graph Engineering for Multi-Agent Systems](https://www.truefoundry.com/blog/graph-engineering-enterprise-guide)

--- a/blog/index.qmd
+++ b/blog/index.qmd
@@ -24,7 +24,8 @@ share: false
 
 ::: {.category-buttons}
 [All](.){.btn .btn-outline-secondary .btn-sm}
-[blog (84)](#category=blog){.btn .btn-outline-primary .btn-sm}
+[ai-generated (5)](#category=ai-generated){.btn .btn-outline-primary .btn-sm}
+[blog (83)](#category=blog){.btn .btn-outline-primary .btn-sm}
 [diary (10)](#category=diary){.btn .btn-outline-primary .btn-sm}
 [memo (4)](#category=memo){.btn .btn-outline-primary .btn-sm}
 [tech (1)](#category=tech){.btn .btn-outline-primary .btn-sm}

--- a/blog/index.qmd
+++ b/blog/index.qmd
@@ -24,11 +24,11 @@ share: false
 
 ::: {.category-buttons}
 [All](.){.btn .btn-outline-secondary .btn-sm}
-[blog (83)](#category=blog){.btn .btn-outline-primary .btn-sm}
+[blog (84)](#category=blog){.btn .btn-outline-primary .btn-sm}
 [diary (10)](#category=diary){.btn .btn-outline-primary .btn-sm}
 [memo (4)](#category=memo){.btn .btn-outline-primary .btn-sm}
 [tech (1)](#category=tech){.btn .btn-outline-primary .btn-sm}
-[tech-ai (20)](#category=tech-ai){.btn .btn-outline-primary .btn-sm}
+[tech-ai (21)](#category=tech-ai){.btn .btn-outline-primary .btn-sm}
 [tech-data (8)](#category=tech-data){.btn .btn-outline-primary .btn-sm}
 [tech-others (31)](#category=tech-others){.btn .btn-outline-primary .btn-sm}
 [tech-vim (13)](#category=tech-vim){.btn .btn-outline-primary .btn-sm}

--- a/en/blog/2026-07-21-agent-org-graph-in-tmux.qmd
+++ b/en/blog/2026-07-21-agent-org-graph-in-tmux.qmd
@@ -1,0 +1,259 @@
+---
+title: "The Smallest Useful Agent Org Graph Fits in tmux"
+author: uma-chan
+categories:
+  - "blog"
+  - "tech-ai"
+  - "ai-generated"
+date: 2026-07-21 21:20:00 +0900
+date-modified: last-modified
+description: |
+  Graph engineering is becoming a useful way to talk about multi-agent systems. tmux-a2a-postman is not an execution graph framework, but it does give terminal agents a local org graph: roles, allowed handoff edges, Markdown mail, and visible reply obligations. #AIAgents #tmux #GraphEngineering #DeveloperTools
+image: "/assets/common/icon_hhkb3_large.jpg"
+---
+
+## 1. The Graph I Actually Needed
+
+"Graph engineering" is starting to become a useful phrase for multi-agent
+systems. The term is still young, but the direction is easy to recognize:
+instead of treating agents as one long chat, name the actors, name the edges,
+and make the handoffs visible.
+
+That vocabulary can get too big too quickly. A graph can mean a workflow
+runtime, a service protocol, a planner, a message queue, a review system, or
+just a diagram. I do not want to blur those together.
+
+The graph I needed was smaller.
+
+I wanted a local map of terminal agents:
+
+- who is the human-facing role;
+- who coordinates work;
+- who implements;
+- who reviews;
+- who may talk to whom;
+- which request still needs a reply.
+
+That is the shape `tmux-a2a-postman` gives me. It is not a LangGraph or AutoGen
+replacement. It is not an A2A protocol implementation. It is a local
+conversation topology for tmux panes, written in Markdown.
+
+Repository: <https://github.com/i9wa4/tmux-a2a-postman>
+
+## 2. Execution Graphs and Conversation Topologies
+
+The distinction matters.
+
+[LangGraph's Graph API](https://docs.langchain.com/oss/python/langgraph/graph-api)
+models agent workflows with state, nodes, and edges. Nodes run logic and return
+state updates. Edges decide what node runs next. The graph is an execution
+structure.
+
+[AutoGen GraphFlow](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/graph-flow.html)
+also describes a directed graph where agents are nodes and edges define allowed
+execution paths. It supports sequential, parallel, conditional, and looping
+flows.
+
+[Google ADK workflows](https://adk.dev/workflows/) describe multi-agent,
+multi-node applications for more predictable and reliable systems, and its
+[A2A documentation](https://adk.dev/a2a/intro/) is about agents communicating
+across services, teams, languages, or frameworks.
+
+Those are stronger and broader surfaces than postman.
+
+`tmux-a2a-postman` does not execute nodes in a graph runtime. The nodes are
+already-running tmux panes. The edges are allowed conversation paths. The
+messages are Markdown mail. The daemon tracks delivery, unread/read state,
+reply-required obligations, and status.
+
+That makes the right comparison narrower: postman is an org graph or
+conversation topology for a local terminal agent team.
+
+## 3. The Small Topology
+
+The minimal useful version is not impressive as a diagram. That is the point.
+
+```{mermaid}
+graph LR
+    messenger["messenger<br/>human-facing"]
+    orchestrator["orchestrator<br/>coordinator"]
+    worker["worker<br/>implementation"]
+    reviewer["reviewer<br/>verification"]
+
+    messenger --- orchestrator
+    orchestrator --- worker
+    orchestrator --- reviewer
+
+    class messenger entry
+    class orchestrator,worker,reviewer role
+    classDef entry fill:#dbeafe,stroke:#2563eb,color:#0f172a
+    classDef role fill:#f8fafc,stroke:#64748b,color:#0f172a
+```
+
+In `postman.md`, the same idea is ordinary Markdown:
+
+````{.markdown filename="postman.md"}
+## `edges`
+
+```mermaid
+graph LR
+    messenger --- orchestrator
+    orchestrator --- worker
+    orchestrator --- reviewer
+    class messenger ui_node
+    classDef ui_node fill:#e0f2fe
+```
+
+## `messenger`
+
+### `role`
+
+Human-facing transport role. Relay work to orchestrator.
+
+## `orchestrator`
+
+### `role`
+
+Coordinator. Delegate implementation to worker and request review from reviewer.
+
+## `worker`
+
+### `role`
+
+Implementation role. Return changed files, checks, evidence, and blockers.
+
+## `reviewer`
+
+### `role`
+
+Verification role. Check the result and return an evidence-backed verdict.
+````
+
+The important part is not the styling. The node names correspond to pane titles
+and role contracts. The `---` edges define who can send mail to whom. The
+`ui_node` class marks the first human-facing role.
+
+That is enough structure to stop relying on pane memory.
+
+## 4. Why a Mailbox Belongs in the Graph
+
+A graph of roles is only useful if work can move through it without vanishing.
+
+Terminal agents already have the execution surface: shells, editors, test
+commands, repository files, and long-lived tmux panes. What disappears is the
+handoff. A request sits in one chat history. A reviewer answers in another
+pane. A human later asks what is still open, and everyone scrolls.
+
+Postman turns the handoff into local state.
+
+A message has a sender and receiver. A receiver claims it with `pop`. Some
+messages are fire-and-forget. Others are reply-required and open an exact input
+request. A completion reply names evidence, the task artifact, the original
+checklist status, and remaining blockers.
+
+That is a small idea, but it changes the operating model. The graph is no
+longer just "orchestrator can talk to worker." It is "orchestrator sent this
+specific request to worker, worker claimed it, and this exact reply slot is
+still open."
+
+The graph becomes a coordination map with memory.
+
+## 5. Where This Fits in the Current Discussion
+
+The current agent discussion is moving upward from prompts toward loops,
+workflows, and organizations.
+
+The Japanese article
+[「Loop EngineeringはGraph Engineeringの中にある」](https://aimanavo.com/c/morphox_ai/a/MAfrDjpPkKGUFw)
+uses "Graph Engineering" to talk about wiring agents as an organization. A
+[TrueFoundry article on graph engineering](https://www.truefoundry.com/blog/graph-engineering-enterprise-guide)
+similarly treats topology, routers, joins, tools, human checkpoints, governance,
+and observability as part of the engineering problem.
+
+I read those as trend signals, not specifications. The settled references are
+still the framework docs: LangGraph, AutoGen, and ADK all show that nodes,
+edges, routing, fan-out, and multi-agent workflow vocabulary are now ordinary
+parts of the agent engineering conversation.
+
+Postman fits the org-graph side of that discussion. It does not provide a
+planner that decides the next node. It does not run a state graph. It does not
+standardize remote service-to-service agent communication. It does make the
+local organization legible:
+
+- stable roles;
+- declared handoff edges;
+- a human-facing entry node;
+- Markdown role contracts;
+- durable mail;
+- explicit reply obligations;
+- status that a human or another agent can inspect.
+
+That is the terminal-sized version of the idea.
+
+## 6. The Useful Constraint
+
+The most useful constraint is that the graph stays boring.
+
+An agent org graph should not start with twenty roles. Mine usually starts with
+four:
+
+- `messenger` talks to the human;
+- `orchestrator` shapes and routes the task;
+- `worker` changes files or investigates;
+- `reviewer` checks evidence.
+
+More roles can appear later: approver, critic, operator, release coordinator.
+But the small graph is already enough to separate responsibilities that do not
+belong in one context window.
+
+The worker does not need to know how to talk to the human. The reviewer does
+not need the worker's whole private reasoning. The messenger does not need to
+inspect the repository. The orchestrator does not need to perform every edit.
+
+The edge list is a pressure valve for context.
+
+## 7. The Honest Boundary
+
+There is a safety boundary here too.
+
+Postman is coordination, not enforcement. A declared edge does not sandbox a
+process. A command approval thread is not an OS permission model. A Markdown
+role contract is not a proof that an agent will behave.
+
+That limitation is not a footnote. It is what keeps the comparison honest.
+
+Use runtime sandboxing, permissions, hooks, CI, branch protection, and human
+approval where those are the right tools. Use postman for the thing it is good
+at: making local agent handoffs explicit, inspectable, and durable enough to
+survive one model context.
+
+The value is not that a Markdown graph replaces an execution framework. The
+value is that a Markdown graph makes the local organization visible before you
+need a heavier one.
+
+## 8. Why This Is Worth Showing
+
+The screenshot-friendly README change that prompted this article puts the
+rendered topology next to the Mermaid source. That pairing is small, but it
+captures the product idea well.
+
+The diagram says: here is the organization.
+
+The source says: here is the contract you can edit.
+
+The mailbox says: here is what happened.
+
+That is the smallest useful agent org graph I have found so far. It fits in
+tmux because the first problem is not executing a distributed graph. The first
+problem is knowing who owns the next message.
+
+## Sources
+
+- [`tmux-a2a-postman`](https://github.com/i9wa4/tmux-a2a-postman)
+- [LangGraph Graph API](https://docs.langchain.com/oss/python/langgraph/graph-api)
+- [LangGraph workflows and agents](https://docs.langchain.com/oss/python/langgraph/workflows-agents)
+- [AutoGen GraphFlow](https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/graph-flow.html)
+- [Google ADK workflows](https://adk.dev/workflows/)
+- [Google ADK A2A introduction](https://adk.dev/a2a/intro/)
+- [Loop EngineeringはGraph Engineeringの中にある](https://aimanavo.com/c/morphox_ai/a/MAfrDjpPkKGUFw)
+- [TrueFoundry: Graph Engineering for Multi-Agent Systems](https://www.truefoundry.com/blog/graph-engineering-enterprise-guide)

--- a/en/blog/index.qmd
+++ b/en/blog/index.qmd
@@ -24,8 +24,8 @@ share: false
 
 ::: {.category-buttons}
 [All](.){.btn .btn-outline-secondary .btn-sm}
-[blog (14)](#category=blog){.btn .btn-outline-primary .btn-sm}
-[tech-ai (14)](#category=tech-ai){.btn .btn-outline-primary .btn-sm}
+[blog (15)](#category=blog){.btn .btn-outline-primary .btn-sm}
+[tech-ai (15)](#category=tech-ai){.btn .btn-outline-primary .btn-sm}
 :::
 
 ## Multi-Agent Systems Series

--- a/en/blog/index.qmd
+++ b/en/blog/index.qmd
@@ -24,6 +24,7 @@ share: false
 
 ::: {.category-buttons}
 [All](.){.btn .btn-outline-secondary .btn-sm}
+[ai-generated (15)](#category=ai-generated){.btn .btn-outline-primary .btn-sm}
 [blog (15)](#category=blog){.btn .btn-outline-primary .btn-sm}
 [tech-ai (15)](#category=tech-ai){.btn .btn-outline-primary .btn-sm}
 :::


### PR DESCRIPTION
## Summary

- Add Japanese blog article `blog/2026-07-21-agent-org-graph-in-tmux.qmd`.
- Add English blog article `en/blog/2026-07-21-agent-org-graph-in-tmux.qmd`.
- Regenerate category buttons in `blog/index.qmd` and `en/blog/index.qmd` with `bin/update-categories.py`.

## Tests

- `git diff --check origin/main..HEAD`
- `uv run quarto render en/blog/2026-07-21-agent-org-graph-in-tmux.qmd`
- `uv run quarto render blog/2026-07-21-agent-org-graph-in-tmux.qmd`
- `uv run quarto render en/blog/index.qmd`
- `uv run quarto render blog/index.qmd`
- `nix flake check --print-build-logs`
